### PR TITLE
Standalone implementation of configuration-gcp-database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/.cache
+/.work
+/_output
+/results
+/.idea
+
+*.xpkg
+kubeconfig

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build"]
+	path = build
+	url = https://github.com/upbound/build

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 
 # This target requires the following environment variables to be set:
 # - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat gcp.json)
+#   make e2e UPTEST_GCP_PROJECT=crossplane-playground to use a different project
 e2e: build controlplane.up local.xpkg.deploy.configuration.$(PROJECT_NAME) uptest
 
 render:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,79 @@
+# Project Setup
+PROJECT_NAME := configuration-gcp-database
+PROJECT_REPO := github.com/upbound/$(PROJECT_NAME)
+
+# NOTE(hasheddan): the platform is insignificant here as Configuration package
+# images are not architecture-specific. We constrain to one platform to avoid
+# needlessly pushing a multi-arch image.
+PLATFORMS ?= linux_amd64
+-include build/makelib/common.mk
+
+# ====================================================================================
+# Setup Kubernetes tools
+
+UP_VERSION = v0.21.0
+UP_CHANNEL = stable
+UPTEST_VERSION = v0.9.0
+
+-include build/makelib/k8s_tools.mk
+# ====================================================================================
+# Setup XPKG
+XPKG_DIR = $(shell pwd)
+XPKG_IGNORE = .github/workflows/*.yaml,.github/workflows/*.yml,examples/*.yaml,.work/uptest-datasource.yaml
+XPKG_REG_ORGS ?= xpkg.upbound.io/upbound
+# NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
+# inferred.
+XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/upbound
+XPKGS = $(PROJECT_NAME)
+-include build/makelib/xpkg.mk
+
+CROSSPLANE_NAMESPACE = upbound-system
+-include build/makelib/local.xpkg.mk
+-include build/makelib/controlplane.mk
+
+# ====================================================================================
+# Targets
+
+# run `make help` to see the targets and options
+
+# We want submodules to be set up the first time `make` is run.
+# We manage the build/ folder and its Makefiles as a submodule.
+# The first time `make` is run, the includes of build/*.mk files will
+# all fail, and this target will be run. The next time, the default as defined
+# by the includes will be run instead.
+fallthrough: submodules
+	@echo Initial setup complete. Running make again . . .
+	@make
+
+# Update the submodules, such as the common build scripts.
+submodules:
+	@git submodule sync
+	@git submodule update --init --recursive
+
+# We must ensure up is installed in tool cache prior to build as including the k8s_tools machinery prior to the xpkg
+# machinery sets UP to point to tool cache.
+build.init: $(UP)
+
+# ====================================================================================
+# End to End Testing
+
+# This target requires the following environment variables to be set:
+# - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat gcp.json)
+uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
+	@$(INFO) running automated tests
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/network-xr.yaml,examples/postgres-claim.yaml --setup-script=test/setup.sh --default-timeout=2400 || $(FAIL)
+	@$(OK) running automated tests
+
+# This target requires the following environment variables to be set:
+# - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat gcp.json)
+e2e: build controlplane.up local.xpkg.deploy.configuration.$(PROJECT_NAME) uptest
+
+render:
+	crossplane beta render examples/postgres-claim.yaml apis/composition.yaml examples/functions.yaml -r
+
+yamllint:
+	@$(INFO) running yamllint
+	@yamllint ./apis || $(FAIL)
+	@$(OK) running yamllint
+
+.PHONY: uptest e2e render yamllint

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # configuration-gcp-database
+
+GCP Database Configuration is reusable Configuration designed to be primarily used in higher level Configurations.

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xpostgresqlinstances.gcp.platform.upbound.io
+  labels:
+    provider: gcp
+spec:
+  writeConnectionSecretsToNamespace: upbound-system
+  compositeTypeRef:
+    apiVersion: gcp.platform.upbound.io/v1alpha1
+    kind: XPostgreSQLInstance
+  mode: Pipeline
+  pipeline:
+    - step: patch-and-transform
+      functionRef:
+        name: upbound-function-patch-and-transform
+      input:
+        apiVersion: pt.fn.crossplane.io/v1beta1
+        kind: Resources
+        resources:
+          - name: PrivateIPAddress
+            base:
+              apiVersion: compute.gcp.upbound.io/v1beta1
+              kind: GlobalAddress
+              spec:
+                forProvider:
+                  addressType: INTERNAL
+                  prefixLength: 16
+                  purpose: VPC_PEERING
+            patches:
+              - fromFieldPath: spec.parameters.networkRef.id
+                toFieldPath: spec.forProvider.networkSelector.matchLabels[networks.gcp.platform.upbound.io/network-id]
+          - name: PrivateConnection
+            base:
+              apiVersion: servicenetworking.gcp.upbound.io/v1beta1
+              kind: Connection
+              spec:
+                forProvider:
+                  reservedPeeringRangesSelector:
+                    matchControllerRef: true
+                  service: servicenetworking.googleapis.com
+            patches:
+              - fromFieldPath: spec.parameters.networkRef.id
+                toFieldPath: spec.forProvider.networkSelector.matchLabels[networks.gcp.platform.upbound.io/network-id]
+          - name: DatabaseUser
+            base:
+              apiVersion: sql.gcp.upbound.io/v1beta1
+              kind: User
+              spec:
+                forProvider:
+                  instanceSelector:
+                    matchControllerRef: true
+            patches:
+              - fromFieldPath: spec.parameters.passwordSecretRef.namespace
+                toFieldPath: spec.forProvider.passwordSecretRef.namespace
+              - fromFieldPath: spec.parameters.passwordSecretRef.name
+                toFieldPath: spec.forProvider.passwordSecretRef.name
+              - fromFieldPath: spec.parameters.passwordSecretRef.key
+                toFieldPath: spec.forProvider.passwordSecretRef.key
+          - name: DBInstance
+            base:
+              apiVersion: sql.gcp.upbound.io/v1beta1
+              kind: DatabaseInstance
+              spec:
+                forProvider:
+                  databaseVersion: POSTGRES_13
+                  deletionProtection: false
+                  region: us-west2
+                  settings:
+                    - diskSize: 20
+                      tier: db-f1-micro
+            patches:
+              - fromFieldPath: metadata.uid
+                toFieldPath: spec.writeConnectionSecretToRef.name
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-gcp-postgresql"
+              - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+                toFieldPath: spec.writeConnectionSecretToRef.namespace
+              - fromFieldPath: spec.parameters.storageGB
+                toFieldPath: spec.forProvider.settings[0].diskSize
+              - fromFieldPath: spec.parameters.networkRef.id
+                toFieldPath: spec.forProvider.settings[0].ipConfiguration[0].privateNetworkRef.name
+            connectionDetails:
+              - name: privateIP
+                type: FromConnectionSecretKey
+                fromConnectionSecretKey: privateIP
+              - name: serverCACertificateCert
+                type: FromConnectionSecretKey
+                fromConnectionSecretKey: serverCACertificateCert

--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -1,0 +1,61 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.gcp.platform.upbound.io
+spec:
+  group: gcp.platform.upbound.io
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  claimNames:
+    kind: PostgreSQLInstance
+    plural: postgresqlinstances
+  connectionSecretKeys:
+    - privateIP
+    - serverCACertificateCert
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    storageGB:
+                      type: integer
+                    passwordSecretRef:
+                      type: object
+                      description: "A reference to the Secret object containing database password"
+                      properties:
+                        namespace:
+                          type: string
+                        name:
+                          type: string
+                        key:
+                          type: string
+                      required:
+                        - namespace
+                        - name
+                        - key
+                    networkRef:
+                      type: object
+                      description: "A reference to the Network object that this postgres should be
+                      connected to."
+                      properties:
+                        id:
+                          type: string
+                          description: ID of the Network object this ref points to.
+                      required:
+                        - id
+                  required:
+                    - storageGB
+                    - networkRef
+                    - passwordSecretRef
+              required:
+                - parameters

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -1,0 +1,22 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: configuration-gcp-database
+  annotations:
+    meta.crossplane.io/maintainer: Upbound <support@upbound.io>
+    meta.crossplane.io/source: github.com/upbound/configuration-gcp-database
+    meta.crossplane.io/license: Apache-2.0
+
+spec:
+  crossplane:
+    version: ">=v1.14.1-0"
+  dependsOn:
+    - provider: xpkg.upbound.io/upbound/provider-gcp-sql
+      # renovate: datasource=github-releases depName=upbound/provider-gcp
+      version: "v0.41.0"
+    - provider: xpkg.upbound.io/upbound/provider-gcp-servicenetworking
+      # renovate: datasource=github-releases depName=upbound/provider-gcp
+      version: "v0.41.0"
+    - configuration: xpkg.upbound.io/upbound/configuration-gcp-network
+      # renovate: datasource=github-releases depName=upbound/configuration-gcp-network
+      version: "v0.1.0"

--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: configuration-gcp-database
+spec:
+  package: xpkg.upbound.io/upbound/configuration-gcp-database:v0.1.0

--- a/examples/functions.yaml
+++ b/examples/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: upbound-function-patch-and-transform
+spec:
+  package: xpkg.upbound.io/upbound/function-patch-and-transform:v0.2.1

--- a/examples/network-xr.yaml
+++ b/examples/network-xr.yaml
@@ -1,0 +1,8 @@
+apiVersion: gcp.platform.upbound.io/v1alpha1
+kind: XNetwork
+metadata:
+  name: configuration-gcp-database
+spec:
+  parameters:
+    id: configuration-gcp-database
+    region: us-west2

--- a/examples/postgres-claim.yaml
+++ b/examples/postgres-claim.yaml
@@ -1,0 +1,25 @@
+apiVersion: gcp.platform.upbound.io/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: configuration-gcp-database
+  namespace: default
+spec:
+  parameters:
+    storageGB: 10
+    passwordSecretRef:
+      namespace: default
+      name: psqlsecret
+      key: password
+    networkRef:
+      id: configuration-gcp-database
+  writeConnectionSecretToRef:
+    name: configuration-gcp-database-conn
+---
+apiVersion: v1
+data:
+  password: dXBiMHVuZHIwY2s1ITMxMzM3
+kind: Secret
+metadata:
+  name: psqlsecret
+  namespace: default
+type: Opaque

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -aeuo pipefail
+
+UPTEST_GCP_PROJECT=${UPTEST_GCP_PROJECT:-official-provider-testing}
+
+echo "Running setup.sh"
+echo "Waiting until all configurations are healthy/installed..."
+"${KUBECTL}" wait configuration.pkg --all --for=condition=Healthy --timeout 5m
+"${KUBECTL}" wait configuration.pkg --all --for=condition=Installed --timeout 5m
+"${KUBECTL}" wait configurationrevisions.pkg --all --for=condition=Healthy --timeout 5m
+
+echo "Creating cloud credential secret..."
+"${KUBECTL}" -n upbound-system create secret generic gcp-creds --from-literal=credentials="${UPTEST_CLOUD_CREDENTIALS}" \
+    --dry-run=client -o yaml | ${KUBECTL} apply -f -
+
+echo "Waiting until all installed provider packages are healthy..."
+"${KUBECTL}" wait provider.pkg --all --for condition=Healthy --timeout 5m
+
+echo "Waiting for all pods to come online..."
+"${KUBECTL}" -n upbound-system wait --for=condition=Available deployment --all --timeout=5m
+
+echo "Waiting for all XRDs to be established..."
+"${KUBECTL}" wait xrd --all --for condition=Established
+
+echo "Creating a default provider config..."
+cat <<EOF | "${KUBECTL}" apply -f -
+apiVersion: gcp.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    secretRef:
+      key: credentials
+      name: gcp-creds
+      namespace: upbound-system
+    source: Secret
+  projectID: ${UPTEST_GCP_PROJECT}
+EOF


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* XRD + Composition
* Reusage of configuration-gcp-network
* uptest setup


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Local run

```
=== CONT  kuttl
    harness.go:402: run tests finished
    harness.go:511: cleaning up
    harness.go:553: skipping cluster tear down
    harness.go:554: to connect to the cluster, run: export KUBECONFIG="/Users/xnull/upbound/configuration-gcp-database/kubeconfig"
--- PASS: kuttl (1095.71s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/case (1095.12s)
PASS
19:07:29 [ OK ] running automated tests
```

centalized uptest run will follow below
