### PR TITLE
Extend configuration with  MySQL support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build.init: $(UP)
 # - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat gcp.json)
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
-	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/network-xr.yaml,examples/postgres-claim.yaml --setup-script=test/setup.sh --default-timeout=2400 || $(FAIL)
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/network-xr.yaml,examples/postgres-claim.yaml,examples/mysql-claim.yaml --setup-script=test/setup.sh --default-timeout=2400 || $(FAIL)
 	@$(OK) running automated tests
 
 # This target requires the following environment variables to be set:

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -8,7 +8,7 @@ spec:
   writeConnectionSecretsToNamespace: upbound-system
   compositeTypeRef:
     apiVersion: gcp.platform.upbound.io/v1alpha1
-    kind: XPostgreSQLInstance
+    kind: XSQLInstance
   mode: Pipeline
   pipeline:
     - step: patch-and-transform
@@ -17,6 +17,22 @@ spec:
       input:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
+        patchSets:
+          - name: providerConfigRef
+            patches:
+              - fromFieldPath: spec.parameters.providerConfigName
+                toFieldPath: spec.providerConfigRef.name
+                type: FromCompositeFieldPath
+          - name: deletionPolicy
+            patches:
+              - fromFieldPath: spec.parameters.deletionPolicy
+                toFieldPath: spec.deletionPolicy
+                type: FromCompositeFieldPath
+          - name: region
+            patches:
+              - fromFieldPath: spec.parameters.region
+                toFieldPath: spec.forProvider.region
+                type: FromCompositeFieldPath
         resources:
           - name: PrivateIPAddress
             base:
@@ -28,6 +44,10 @@ spec:
                   prefixLength: 16
                   purpose: VPC_PEERING
             patches:
+              - type: PatchSet
+                patchSetName: providerConfigRef
+              - type: PatchSet
+                patchSetName: deletionPolicy
               - fromFieldPath: spec.parameters.networkRef.id
                 toFieldPath: spec.forProvider.networkSelector.matchLabels[networks.gcp.platform.upbound.io/network-id]
           - name: PrivateConnection
@@ -40,6 +60,10 @@ spec:
                     matchControllerRef: true
                   service: servicenetworking.googleapis.com
             patches:
+              - type: PatchSet
+                patchSetName: providerConfigRef
+              - type: PatchSet
+                patchSetName: deletionPolicy
               - fromFieldPath: spec.parameters.networkRef.id
                 toFieldPath: spec.forProvider.networkSelector.matchLabels[networks.gcp.platform.upbound.io/network-id]
           - name: DatabaseUser
@@ -51,12 +75,25 @@ spec:
                   instanceSelector:
                     matchControllerRef: true
             patches:
+              - type: PatchSet
+                patchSetName: providerConfigRef
+              - type: PatchSet
+                patchSetName: deletionPolicy
               - fromFieldPath: spec.parameters.passwordSecretRef.namespace
                 toFieldPath: spec.forProvider.passwordSecretRef.namespace
               - fromFieldPath: spec.parameters.passwordSecretRef.name
                 toFieldPath: spec.forProvider.passwordSecretRef.name
               - fromFieldPath: spec.parameters.passwordSecretRef.key
                 toFieldPath: spec.forProvider.passwordSecretRef.key
+              - type: CombineFromComposite
+                combine:
+                  variables:
+                    - fromFieldPath: spec.parameters.engine
+                    - fromFieldPath: metadata.uid
+                  strategy: string
+                  string:
+                    fmt: "%suser-%.8s"  # mysql has a limit of 32 chars for users thus we need to limit the length
+                toFieldPath: metadata.annotations[crossplane.io/external-name]
           - name: DBInstance
             base:
               apiVersion: sql.gcp.upbound.io/v1beta1
@@ -65,11 +102,16 @@ spec:
                 forProvider:
                   databaseVersion: POSTGRES_13
                   deletionProtection: false
-                  region: us-west2
                   settings:
                     - diskSize: 20
                       tier: db-f1-micro
             patches:
+              - type: PatchSet
+                patchSetName: providerConfigRef
+              - type: PatchSet
+                patchSetName: deletionPolicy
+              - type: PatchSet
+                patchSetName: region
               - fromFieldPath: metadata.uid
                 toFieldPath: spec.writeConnectionSecretToRef.name
                 transforms:
@@ -83,6 +125,20 @@ spec:
                 toFieldPath: spec.forProvider.settings[0].diskSize
               - fromFieldPath: spec.parameters.networkRef.id
                 toFieldPath: spec.forProvider.settings[0].ipConfiguration[0].privateNetworkRef.name
+              - type: CombineFromComposite
+                combine:
+                  variables:
+                    - fromFieldPath: spec.parameters.engine
+                    - fromFieldPath: spec.parameters.engineVersion
+                  strategy: string
+                  string:
+                    fmt: "%s_%s"
+                toFieldPath: spec.forProvider.databaseVersion
+                transforms:
+                  - type: string
+                    string:
+                      type: Convert
+                      convert: "ToUpper"
             connectionDetails:
               - name: privateIP
                 type: FromConnectionSecretKey

--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xpostgresqlinstances.gcp.platform.upbound.io
+  name: xsqlinstances.gcp.platform.upbound.io
 spec:
   group: gcp.platform.upbound.io
   names:
-    kind: XPostgreSQLInstance
-    plural: xpostgresqlinstances
+    kind: XSQLInstance
+    plural: xsqlinstances
   claimNames:
-    kind: PostgreSQLInstance
-    plural: postgresqlinstances
+    kind: SQLInstance
+    plural: sqlinstances
   connectionSecretKeys:
     - privateIP
     - serverCACertificateCert
@@ -27,6 +27,29 @@ spec:
                 parameters:
                   type: object
                   properties:
+                    deletionPolicy:
+                      description: Delete the external resources when the Claim/XR is deleted. Defaults to Delete
+                      enum:
+                        - Delete
+                        - Orphan
+                      type: string
+                      default: Delete
+                    providerConfigName:
+                      description: Crossplane ProviderConfig to use for provisioning this resources
+                      type: string
+                      default: default
+                    region:
+                      type: string
+                      description: Region is the region you'd like your resource to be created in.
+                    engine:
+                      type: string
+                      description: This SQLInstance engine
+                      enum:
+                        - postgres
+                        - mysql
+                    engineVersion:
+                      type: string
+                      description: This SQLInstance engine version
                     storageGB:
                       type: integer
                     passwordSecretRef:
@@ -54,6 +77,7 @@ spec:
                       required:
                         - id
                   required:
+                    - region
                     - storageGB
                     - networkRef
                     - passwordSecretRef

--- a/examples/mysql-claim.yaml
+++ b/examples/mysql-claim.yaml
@@ -1,28 +1,28 @@
 apiVersion: gcp.platform.upbound.io/v1alpha1
 kind: SQLInstance
 metadata:
-  name: configuration-gcp-database-postgres
+  name: configuration-gcp-database-mysql
   namespace: default
 spec:
   parameters:
-    engine: postgres
-    engineVersion: "13"
+    engine: mysql
+    engineVersion: "8_0"
     region: us-west2
     storageGB: 10
     passwordSecretRef:
       namespace: default
-      name: psqlsecret
+      name: mysqlsecret
       key: password
     networkRef:
       id: configuration-gcp-database
   writeConnectionSecretToRef:
-    name: configuration-gcp-database-postgres-conn
+    name: configuration-gcp-database-mysql-conn
 ---
 apiVersion: v1
 data:
   password: dXBiMHVuZHIwY2s1ITMxMzM3
 kind: Secret
 metadata:
-  name: psqlsecret
+  name: mysqlsecret
   namespace: default
 type: Opaque


### PR DESCRIPTION


### Description of your changes

* Extend Configuration with engine selection capability
* Add common XRD fields and PatchSets according to best practices

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`make e2e` locally + uptest below
