### PR TITLE
SQLInstance connection secret extension and configuration enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,14 +59,16 @@ build.init: $(UP)
 
 # This target requires the following environment variables to be set:
 # - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat gcp.json)
+SKIP_DELETE ?=
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
-	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/network-xr.yaml,examples/postgres-claim.yaml,examples/mysql-claim.yaml --setup-script=test/setup.sh --default-timeout=2400 || $(FAIL)
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/network-xr.yaml,examples/postgres-claim.yaml,examples/mysql-claim.yaml --setup-script=test/setup.sh --default-timeout=2400 $(SKIP_DELETE) || $(FAIL)
 	@$(OK) running automated tests
 
 # This target requires the following environment variables to be set:
 # - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat gcp.json)
 #   make e2e UPTEST_GCP_PROJECT=crossplane-playground to use a different project
+# Use `make e2e SKIP_DELETE=--skip-delete` to skip deletion of resources created during the test.
 e2e: build controlplane.up local.xpkg.deploy.configuration.$(PROJECT_NAME) uptest
 
 render:

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -94,6 +94,10 @@ spec:
                   string:
                     fmt: "%suser-%.8s"  # mysql has a limit of 32 chars for users thus we need to limit the length
                 toFieldPath: metadata.annotations[crossplane.io/external-name]
+            connectionDetails:
+              - name: username
+                type: FromFieldPath
+                fromFieldPath: metadata.annotations[crossplane.io/external-name]
           - name: DBInstance
             base:
               apiVersion: sql.gcp.upbound.io/v1beta1
@@ -112,13 +116,15 @@ spec:
                 patchSetName: deletionPolicy
               - type: PatchSet
                 patchSetName: region
-              - fromFieldPath: metadata.uid
+              - type: CombineFromComposite
+                combine:
+                  variables:
+                    - fromFieldPath: metadata.uid
+                    - fromFieldPath: spec.parameters.engine
+                  strategy: string
+                  string:
+                    fmt: "%s-gcp-%s"
                 toFieldPath: spec.writeConnectionSecretToRef.name
-                transforms:
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-gcp-postgresql"
               - fromFieldPath: spec.writeConnectionSecretToRef.namespace
                 toFieldPath: spec.writeConnectionSecretToRef.namespace
               - fromFieldPath: spec.parameters.storageGB
@@ -140,7 +146,7 @@ spec:
                       type: Convert
                       convert: "ToUpper"
             connectionDetails:
-              - name: privateIP
+              - name: host
                 type: FromConnectionSecretKey
                 fromConnectionSecretKey: privateIP
               - name: serverCACertificateCert

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -94,10 +94,24 @@ spec:
                   string:
                     fmt: "%suser-%.8s"  # mysql has a limit of 32 chars for users thus we need to limit the length
                 toFieldPath: metadata.annotations[crossplane.io/external-name]
+              - type: CombineFromComposite
+                combine:
+                  variables:
+                    - fromFieldPath: metadata.uid
+                    - fromFieldPath: spec.parameters.engine
+                  strategy: string
+                  string:
+                    fmt: "%s-gcp-%s-user"
+                toFieldPath: spec.writeConnectionSecretToRef.name
+              - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+                toFieldPath: spec.writeConnectionSecretToRef.namespace
             connectionDetails:
               - name: username
                 type: FromFieldPath
                 fromFieldPath: metadata.annotations[crossplane.io/external-name]
+              - name: password
+                type: FromConnectionSecretKey
+                fromConnectionSecretKey: password
           - name: DBInstance
             base:
               apiVersion: sql.gcp.upbound.io/v1beta1

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -111,7 +111,7 @@ spec:
                 fromFieldPath: metadata.annotations[crossplane.io/external-name]
               - name: password
                 type: FromConnectionSecretKey
-                fromConnectionSecretKey: password
+                fromConnectionSecretKey: attribute.password
           - name: DBInstance
             base:
               apiVersion: sql.gcp.upbound.io/v1beta1

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -127,7 +127,7 @@ spec:
                 patchSetName: deletionPolicy
               - type: FromCompositeFieldPath
                 fromFieldPath: metadata.name
-                toFieldPath: metadata.name
+                toFieldPath: metadata.annotations[crossplane.io/external-name]
                 transforms:
                   - type: match
                     match:
@@ -142,7 +142,6 @@ spec:
               kind: DatabaseInstance
               spec:
                 forProvider:
-                  databaseVersion: POSTGRES_13
                   deletionProtection: false
                   settings:
                     - diskSize: 20

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xpostgresqlinstances.gcp.platform.upbound.io
+  name: xsqlinstances.gcp.platform.upbound.io
   labels:
     provider: gcp
 spec:

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -112,6 +112,30 @@ spec:
               - name: password
                 type: FromConnectionSecretKey
                 fromConnectionSecretKey: attribute.password
+          - name: UpboundDatabase
+            base:
+              apiVersion: sql.gcp.upbound.io/v1beta1
+              kind: Database
+              spec:
+                forProvider:
+                  instanceSelector:
+                    matchControllerRef: true
+            patches:
+              - type: PatchSet
+                patchSetName: providerConfigRef
+              - type: PatchSet
+                patchSetName: deletionPolicy
+              - type: FromCompositeFieldPath
+                fromFieldPath: metadata.name
+                toFieldPath: metadata.name
+                transforms:
+                  - type: match
+                    match:
+                      fallbackValue: null
+                      patterns:
+                        - regexp: .*
+                          result: upbound
+                          type: regexp
           - name: DBInstance
             base:
               apiVersion: sql.gcp.upbound.io/v1beta1

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -146,6 +146,8 @@ spec:
                   settings:
                     - diskSize: 20
                       tier: db-f1-micro
+                      ipConfiguration:
+                        - ipv4Enabled: false
             patches:
               - type: PatchSet
                 patchSetName: providerConfigRef

--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -11,7 +11,9 @@ spec:
     kind: SQLInstance
     plural: sqlinstances
   connectionSecretKeys:
-    - privateIP
+    - username
+    - password
+    - host
     - serverCACertificateCert
   versions:
     - name: v1alpha1


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Propagate `host`, `username` and `password` as part of SQLInstance connection secret in symmetry to [configuration-aws-database](https://github.com/upbound/configuration-aws-database) and [configuration-azure-database](https://github.com/upbound/configuration-azure-database)
* Fix composed resource level connection secret names for DatabaseInstance to reflect engine properly
* Propagate connection secret from User.Sql
* Add `SKIP_DELETE` uptest capability for convenient testing 
* Add `upbound` Database creation
* More secure DatabaseInstance configuration with disabling PublicIP address and public access for DatabaseInstance

Related (non-blocking) provider-upjet-gcp change https://github.com/crossplane-contrib/provider-upjet-gcp/pull/501  

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
```
make e2e SKIP_DELETE=--skip-delete
k get secret
NAME                                       TYPE                                DATA   AGE
configuration-gcp-database-mysql-conn      connection.crossplane.io/v1alpha1   4      95m
configuration-gcp-database-postgres-conn   connection.crossplane.io/v1alpha1   4      96m
k view-secret configuration-gcp-database-postgres-conn
Multiple sub keys found. Specify another argument, one of:
-> host
-> password
-> serverCACertificateCert
-> username

k view-secret configuration-gcp-database-mysql-conn
Multiple sub keys found. Specify another argument, one of:
-> host
-> password
-> serverCACertificateCert
-> username
```
