### PR TITLE
Fix global address network space to avoid clash with GKE subnets

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -40,6 +40,7 @@ spec:
               kind: GlobalAddress
               spec:
                 forProvider:
+                  address: 10.205.0.0
                   addressType: INTERNAL
                   prefixLength: 16
                   purpose: VPC_PEERING


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Currently, if we test platform-ref-gcp we hit failure for Connection due to overlapping subnetworks

```
managed/servicenetworking.gcp.upbound.io/v1beta1, kind=connection  (combined from similar events): async create failed: failed to create the resource: [{0 Error waiting for Create Service Networking Connection: Error code 3, message: An IP range in the peer network (10.202.0.0/24) overlaps with an IP range in the local network (10.200.0.0/14) allocated by resource (projects/official-provider-testing/regions/us-west2/subnetworks/platform-ref-gcp-nn2hm-kscqx).
```

The clash is happening with secondary IP ranges in https://github.com/upbound/configuration-gcp-network/blob/main/apis/default/composition.yaml#L68-L72

And happens only when we test the whole https://github.com/upbound/platform-ref-gcp/ where both gcp-gke and gcp-database is deployed in parallel to the same network.

This change attempts to isolate GlobalAddress network range and make it non-clashing with the ranges that are comping from gcp-network

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Locally plus uptest below