### PR TITLE
Propagate database connection secret

### DIFF
--- a/functions/xsqlinstance/main.k
+++ b/functions/xsqlinstance/main.k
@@ -5,6 +5,7 @@ import models.io.upbound.gcp.sql.v1beta1 as sqlv1beta1
 import models.io.upbound.platform.gcp.v1alpha1 as platformgcpv1alpha1
 
 oxr = platformgcpv1alpha1.XSQLInstance{**option("params").oxr}
+_ocds = option("params").ocds
 params = oxr.spec.parameters
 providerConfigRefName = params.providerConfigName or "default"
 
@@ -25,6 +26,20 @@ _connection_secret_name = lambda suffix: str -> str {
     "{}-gcp-{}-{}".format(_uid, params.engine, suffix)
 }
 
+# Forward connection details from DatabaseInstance and User
+_connection_details = {
+    apiVersion = "meta.krm.kcl.dev/v1alpha1"
+    kind = "CompositeConnectionDetails"
+    if "DBInstance" in _ocds and "DatabaseUser" in _ocds:
+        data = {
+            host = _ocds["DBInstance"].ConnectionDetails.privateIP
+            serverCACertificateCert = _ocds["DBInstance"].ConnectionDetails.serverCACertificateCert
+            username = "upbounduser"
+            password = _ocds["DatabaseUser"].ConnectionDetails.password
+        }
+    else:
+        data = {}
+}
 
 _items = [
     computev1beta1.GlobalAddress{
@@ -123,6 +138,7 @@ _items = [
             }
         }
     }
+    _connection_details
 ]
 
 items = _items


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Connection Details Aggregation

From DatabaseInstance secret (DBInstance):
  - host ← privateIP
  - serverCACertificateCert ← serverCACertificateCert

From User secret (DatabaseUser):
- password ← password

Static value:
- username = "upbounduser"


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Acceptance test with a higher-level platform-ref-gcp abstraction.

```
crossplane beta trace sqlinstance.gcp.platform.upbound.io/platform-ref-gcp-database-mysql-test
NAME                                                                      SYNCED   READY   STATUS
SQLInstance/platform-ref-gcp-database-mysql-test (default)                True     True    Available
└─ XSQLInstance/platform-ref-gcp-database-mysql-test-4bvjd                True     True    Available
   ├─ GlobalAddress/platform-ref-gcp-database-mysql-test-4bvjd-xm62l      True     True    Available
   ├─ Connection/platform-ref-gcp-database-mysql-test-4bvjd-jkd4p         True     True    Available
   ├─ DatabaseInstance/platform-ref-gcp-database-mysql-test-4bvjd-psv69   True     True    Available
   ├─ Database/platform-ref-gcp-database-mysql-test-4bvjd-ftbhv           True     True    Available
   └─ User/platform-ref-gcp-database-mysql-test-4bvjd-tzsbx               True     True    Available
...
k view-secret platform-ref-gcp-database-mysql-conn
Multiple sub keys found. Specify another argument, one of:
-> host
-> password
-> serverCACertificateCert
-> username
```

configuration-app is correctly picking up the generated secret
```
crossplane beta trace app.platform.upbound.io/platform-ref-gcp-ghost
NAME                                               SYNCED   READY   STATUS
App/platform-ref-gcp-ghost (default)               True     True    Available
└─ XApp/platform-ref-gcp-ghost-9x7xk               True     True    Available
   └─ Release/platform-ref-gcp-ghost-9x7xk-tzhxn   True     True    Available
```