### PR TITLE
Fix DatabaseUser connection secret to propagate password and introduce resource ordering

### DIFF
--- a/functions/sqlinstance/main.k
+++ b/functions/sqlinstance/main.k
@@ -30,9 +30,11 @@ _connection_secret_name = lambda suffix: str -> str {
     "{}-gcp-{}-{}".format(_uid, params.engine, suffix)
 }
 
-# Check if DBInstance is ready before creating dependent resources
+# Check if DBInstance is actually running before creating dependent resources.
+# privateIpAddress is only populated once GCP reports the instance as RUNNABLE,
+# which is later than Crossplane's Ready=True condition.
 _dbInstanceResource = _ocds["DBInstance"] if _ocds and "DBInstance" in _ocds else None
-_dbInstanceReady = len([c for c in (_dbInstanceResource?.Resource?.status?.conditions or []) if c.type == "Ready" and c.status == "True"]) > 0
+_dbInstanceReady = (_dbInstanceResource?.Resource?.status?.atProvider?.privateIpAddress or "") != ""
 
 # Safety: keep dependent resources if they already exist (prevent accidental deletion)
 _dbUserExists = "DatabaseUser" in _ocds if _ocds else False

--- a/functions/sqlinstance/main.k
+++ b/functions/sqlinstance/main.k
@@ -30,6 +30,14 @@ _connection_secret_name = lambda suffix: str -> str {
     "{}-gcp-{}-{}".format(_uid, params.engine, suffix)
 }
 
+# Check if DBInstance is ready before creating dependent resources
+_dbInstanceResource = _ocds["DBInstance"] if _ocds and "DBInstance" in _ocds else None
+_dbInstanceReady = len([c for c in (_dbInstanceResource?.Resource?.status?.conditions or []) if c.type == "Ready" and c.status == "True"]) > 0
+
+# Safety: keep dependent resources if they already exist (prevent accidental deletion)
+_dbUserExists = "DatabaseUser" in _ocds if _ocds else False
+_dbExists = "UpboundDatabase" in _ocds if _ocds else False
+
 # Manual Secret composition for v2 (replaces CompositeConnectionDetails)
 _connection_secret = corev1.Secret{
     metadata = _metadata("connection-secret") | {
@@ -107,43 +115,46 @@ _items = [
             }
         }
     }
-    sqlv1beta1.User{
-        metadata = _metadata("DatabaseUser") | {
-            annotations = {
-                "crossplane.io/external-name" = "upbounduser"
-                "krm.kcl.dev/composition-resource-name" = "DatabaseUser"
-            }
-        }
-        spec = _defaults | {
-            writeConnectionSecretToRef = {
-                name = _connection_secret_name("user")
-            }
-            forProvider = {
-                instanceSelector = {
-                    matchControllerRef = True
-                }
-                passwordSecretRef = {
-                    name = params.passwordSecretRef.name
-                    key = params.passwordSecretRef.key
+    if _dbInstanceReady or _dbUserExists:
+        sqlv1beta1.User{
+            metadata = _metadata("DatabaseUser") | {
+                annotations = {
+                    "crossplane.io/external-name" = "upbounduser"
+                    "krm.kcl.dev/composition-resource-name" = "DatabaseUser"
                 }
             }
-        }
-    }
-    sqlv1beta1.Database{
-        metadata = _metadata("UpboundDatabase") | {
-            annotations = {
-                "crossplane.io/external-name" = "upbound"
-                "krm.kcl.dev/composition-resource-name" = "UpboundDatabase"
-            }
-        }
-        spec = _defaults | {
-            forProvider = {
-                instanceSelector = {
-                    matchControllerRef = True
+            spec = _defaults | {
+                writeConnectionSecretToRef = {
+                    name = _connection_secret_name("user")
+                }
+                forProvider = {
+                    instanceSelector = {
+                        matchControllerRef = True
+                    }
+                    passwordSecretRef = {
+                        name = params.passwordSecretRef.name
+                        key = params.passwordSecretRef.key
+                    }
                 }
             }
         }
-    }
+
+    if _dbInstanceReady or _dbExists:
+        sqlv1beta1.Database{
+            metadata = _metadata("UpboundDatabase") | {
+                annotations = {
+                    "crossplane.io/external-name" = "upbound"
+                    "krm.kcl.dev/composition-resource-name" = "UpboundDatabase"
+                }
+            }
+            spec = _defaults | {
+                forProvider = {
+                    instanceSelector = {
+                        matchControllerRef = True
+                    }
+                }
+            }
+        }
     _connection_secret
 ]
 

--- a/functions/sqlinstance/main.k
+++ b/functions/sqlinstance/main.k
@@ -111,6 +111,7 @@ _items = [
                         ipv4Enabled = False
                         privateNetworkRef = {
                             name = params.networkRef.id
+                            namespace = oxr.metadata.namespace
                         }
                     }
                 }

--- a/functions/sqlinstance/main.k
+++ b/functions/sqlinstance/main.k
@@ -115,6 +115,9 @@ _items = [
             }
         }
         spec = _defaults | {
+            writeConnectionSecretToRef = {
+                name = _connection_secret_name("user")
+            }
             forProvider = {
                 instanceSelector = {
                     matchControllerRef = True

--- a/tests/test-sqlinstance-mysql/main.k
+++ b/tests/test-sqlinstance-mysql/main.k
@@ -186,14 +186,7 @@ _items = [
                         }
                     }
                     spec.forProvider.region = "us-west2"
-                    status = {
-                        conditions = [{
-                            type = "Ready"
-                            status = "True"
-                            reason = "Available"
-                            lastTransitionTime = "2024-01-01T00:00:00Z"
-                        }]
-                    }
+                    status.atProvider.privateIpAddress = "10.205.0.2"
                 }
             ]
         }

--- a/tests/test-sqlinstance-mysql/main.k
+++ b/tests/test-sqlinstance-mysql/main.k
@@ -178,6 +178,24 @@ _items = [
             xrdPath: "apis/sqlinstances/definition.yaml"
             timeoutSeconds: 60
             validate: False
+            observedResources = [
+                sqlv1beta1.DatabaseInstance{
+                    metadata = {
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "DBInstance"
+                        }
+                    }
+                    spec.forProvider.region = "us-west2"
+                    status = {
+                        conditions = [{
+                            type = "Ready"
+                            status = "True"
+                            reason = "Available"
+                            lastTransitionTime = "2024-01-01T00:00:00Z"
+                        }]
+                    }
+                }
+            ]
         }
     }
 ]

--- a/tests/test-sqlinstance-mysql/main.k
+++ b/tests/test-sqlinstance-mysql/main.k
@@ -132,6 +132,9 @@ _items = [
                     }
                     spec = {
                         managementPolicies = ["*"]
+                        writeConnectionSecretToRef = {
+                            name = "test-mysql-instance-gcp-mysql-user"
+                        }
                         forProvider = {
                             instanceSelector = {
                                 matchControllerRef = True

--- a/tests/test-sqlinstance-postgres/main.k
+++ b/tests/test-sqlinstance-postgres/main.k
@@ -34,6 +34,35 @@ _items = [
                         }
                     }
                 }
+                sqlv1beta1.User{
+                    metadata = {
+                        labels = {
+                            "crossplane.io/composite" = "test-postgres-instance"
+                        }
+                        annotations = {
+                            "crossplane.io/external-name" = "upbounduser"
+                        }
+                    }
+                    spec = {
+                        managementPolicies = ["*"]
+                        writeConnectionSecretToRef = {
+                            name = "test-postgres-instance-gcp-postgres-user"
+                        }
+                        forProvider = {
+                            instanceSelector = {
+                                matchControllerRef = True
+                            }
+                            passwordSecretRef = {
+                                name = "postgresqlsecret"
+                                key = "password"
+                            }
+                        }
+                        providerConfigRef = {
+                            kind = "ProviderConfig"
+                            name = "default"
+                        }
+                    }
+                }
             ]
             compositionPath: "apis/sqlinstances/composition.yaml"
             xrPath: "examples/postgres-xr.yaml"

--- a/tests/test-sqlinstance-postgres/main.k
+++ b/tests/test-sqlinstance-postgres/main.k
@@ -77,14 +77,7 @@ _items = [
                         }
                     }
                     spec.forProvider.region = "us-west2"
-                    status = {
-                        conditions = [{
-                            type = "Ready"
-                            status = "True"
-                            reason = "Available"
-                            lastTransitionTime = "2024-01-01T00:00:00Z"
-                        }]
-                    }
+                    status.atProvider.privateIpAddress = "10.205.0.2"
                 }
             ]
         }

--- a/tests/test-sqlinstance-postgres/main.k
+++ b/tests/test-sqlinstance-postgres/main.k
@@ -69,6 +69,24 @@ _items = [
             xrdPath: "apis/sqlinstances/definition.yaml"
             timeoutSeconds: 60
             validate: False
+            observedResources = [
+                sqlv1beta1.DatabaseInstance{
+                    metadata = {
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "DBInstance"
+                        }
+                    }
+                    spec.forProvider.region = "us-west2"
+                    status = {
+                        conditions = [{
+                            type = "Ready"
+                            status = "True"
+                            reason = "Available"
+                            lastTransitionTime = "2024-01-01T00:00:00Z"
+                        }]
+                    }
+                }
+            ]
         }
     }
 ]


### PR DESCRIPTION
## Summary

- Add `writeConnectionSecretToRef` to the `DatabaseUser` (sqlv1beta1.User) managed resource
- Without this field the GCP SQL provider never published connection details, so `ConnectionDetails?.password` was always empty
- This caused downstream consumers (e.g. the Ghost Helm chart via configuration-app) to fail with a missing `--set` value
- Add explicit safe resource ordering: create Database and DatabaseUser only after DatabaseInstance is ready - increases deployment time and reduces the error noise compared to original unordered implementation

## Test plan

- [x] `up test run tests/test-sqlinstance-mysql tests/test-sqlinstance-postgres` passes